### PR TITLE
Avoid cartesian products in actor-rdf-join-inner-multi-smallest

### DIFF
--- a/packages/actor-rdf-join-inner-multi-smallest/lib/ActorRdfJoinMultiSmallest.ts
+++ b/packages/actor-rdf-join-inner-multi-smallest/lib/ActorRdfJoinMultiSmallest.ts
@@ -40,6 +40,30 @@ export class ActorRdfJoinMultiSmallest extends ActorRdfJoin<IActorRdfJoinMultiSm
   }
 
   /**
+   * Finds join indexes of lowest cardinality result sets, with priority on result sets that have common variables
+   * @param entries A sorted array of entries, sorted on cardinality
+   */
+  public getJoinIndexes(entries: IJoinEntryWithMetadata[]): [number, number] {
+    // Iterate over all combinations of join indexes,
+    // return the first combination that does not lead to a cartesian product
+    for (let i = 0; i < entries.length; i++) {
+      for (let j = i + 1; j < entries.length; j++) {
+        if (this.hasCommonVariables(entries[i], entries[j])) {
+          return [ i, j ];
+        }
+      }
+    }
+    // If all result sets are disjoint we just want the sets with lowest cardinality
+    return [ 0, 1 ];
+  }
+
+  public hasCommonVariables(entry1: IJoinEntryWithMetadata, entry2: IJoinEntryWithMetadata): boolean {
+    const variableNames1 = entry1.metadata.variables.map(x => x.variable.value);
+    const variableNames2 = new Set(entry2.metadata.variables.map(x => x.variable.value));
+    return variableNames1.some(v => variableNames2.has(v));
+  }
+
+  /**
    * Order the given join entries using the join-entries-sort bus.
    * @param {IJoinEntryWithMetadata[]} entries An array of join entries.
    * @param context The action context.
@@ -61,9 +85,13 @@ export class ActorRdfJoinMultiSmallest extends ActorRdfJoin<IActorRdfJoinMultiSm
 
     // Determine the two smallest streams by sorting (e.g. via cardinality)
     const entries: IJoinEntry[] = sideData.sortedEntries;
-    const smallestEntry1 = entries[0];
-    const smallestEntry2 = entries[1];
-    entries.splice(0, 2);
+    const entriesMetaData = await ActorRdfJoin.getEntriesWithMetadatas(entries);
+    const bestJoinIndexes: number[] = this.getJoinIndexes(entriesMetaData);
+
+    const smallestEntry1 = entries[bestJoinIndexes[0]];
+    const smallestEntry2 = entries[bestJoinIndexes[1]];
+    entries.splice(bestJoinIndexes[1], 1);
+    entries.splice(bestJoinIndexes[0], 1);
 
     // Join the two selected streams, and then join the result with the remaining streams
     const firstEntry: IJoinEntry = {
@@ -96,14 +124,11 @@ export class ActorRdfJoinMultiSmallest extends ActorRdfJoin<IActorRdfJoinMultiSm
     const requestItemTimes = ActorRdfJoin.getRequestItemTimes(metadatas);
 
     return passTestWithSideData({
-      iterations: metadatas[0].cardinality.value * metadatas[1].cardinality.value *
-        metadatas.slice(2).reduce((acc, metadata) => acc * metadata.cardinality.value, 1),
+      iterations: metadatas.reduce((acc, metadata) => acc * metadata.cardinality.value, 1),
       persistedItems: 0,
       blockingItems: 0,
-      requestTime: requestInitialTimes[0] + metadatas[0].cardinality.value * requestItemTimes[0] +
-        requestInitialTimes[1] + metadatas[1].cardinality.value * requestItemTimes[1] +
-        metadatas.slice(2).reduce((sum, metadata, i) => sum + requestInitialTimes.slice(2)[i] +
-          metadata.cardinality.value * requestItemTimes.slice(2)[i], 0),
+      requestTime: metadatas.reduce((sum, metadata, i) => sum + requestInitialTimes[i] +
+          metadata.cardinality.value * requestItemTimes[i], 0),
     }, { ...sideData, sortedEntries });
   }
 }

--- a/packages/actor-rdf-join-inner-multi-smallest/test/ActorRdfJoinMultiSmallest-test.ts
+++ b/packages/actor-rdf-join-inner-multi-smallest/test/ActorRdfJoinMultiSmallest-test.ts
@@ -6,7 +6,7 @@ import type { IActionRdfJoinSelectivity, IActorRdfJoinSelectivityOutput } from '
 import { KeysInitQuery } from '@comunica/context-entries';
 import type { Actor, IActorTest, Mediator } from '@comunica/core';
 import { ActionContext, Bus } from '@comunica/core';
-import type { IActionContext } from '@comunica/types';
+import type { IActionContext, IJoinEntryWithMetadata } from '@comunica/types';
 import { BindingsFactory } from '@comunica/utils-bindings-factory';
 import { MetadataValidationState } from '@comunica/utils-metadata';
 import type * as RDF from '@rdfjs/types';
@@ -59,6 +59,7 @@ IActorRdfJoinSelectivityOutput
     let actor: ActorRdfJoinMultiSmallest;
     let action3: () => IActionRdfJoin;
     let action4: () => IActionRdfJoin;
+    let action5: () => IActionRdfJoin;
     let invocationCounter: any;
 
     beforeEach(() => {
@@ -303,11 +304,163 @@ IActorRdfJoinSelectivityOutput
         ],
         context,
       });
+      action5 = () => ({
+        type: 'inner',
+        entries: [
+          {
+            output: {
+              bindingsStream: new ArrayIterator<RDF.Bindings>([
+                BF.bindings([
+                  [ DF.variable('a'), DF.literal('a1') ],
+                  [ DF.variable('b'), DF.literal('b1') ],
+                ]),
+                BF.bindings([
+                  [ DF.variable('a'), DF.literal('a2') ],
+                  [ DF.variable('b'), DF.literal('b2') ],
+                ]),
+              ]),
+              metadata: () => Promise.resolve(
+                {
+                  state: new MetadataValidationState(),
+                  cardinality: { type: 'estimate', value: 4 },
+                  pageSize: 100,
+                  requestTime: 10,
+
+                  variables: [
+                    { variable: DF.variable('a'), canBeUndef: false },
+                    { variable: DF.variable('b'), canBeUndef: false },
+                  ],
+                },
+              ),
+              type: 'bindings',
+            },
+            operation: <any> {},
+          },
+          {
+            output: {
+              bindingsStream: new ArrayIterator<RDF.Bindings>([
+                BF.bindings([
+                  [ DF.variable('c'), DF.literal('c1') ],
+                  [ DF.variable('d'), DF.literal('d1') ],
+                ]),
+                BF.bindings([
+                  [ DF.variable('c'), DF.literal('c2') ],
+                  [ DF.variable('d'), DF.literal('d2') ],
+                ]),
+              ]),
+              metadata: () => Promise.resolve(
+                {
+                  state: new MetadataValidationState(),
+                  cardinality: { type: 'estimate', value: 5 },
+                  pageSize: 100,
+                  requestTime: 20,
+
+                  variables: [
+                    { variable: DF.variable('c'), canBeUndef: false },
+                    { variable: DF.variable('d'), canBeUndef: false },
+                  ],
+                },
+              ),
+              type: 'bindings',
+            },
+            operation: <any> {},
+          },
+          {
+            output: {
+              bindingsStream: new ArrayIterator<RDF.Bindings>([
+                BF.bindings([
+                  [ DF.variable('a'), DF.literal('a1') ],
+                  [ DF.variable('b'), DF.literal('b1') ],
+                ]),
+                BF.bindings([
+                  [ DF.variable('a'), DF.literal('a2') ],
+                  [ DF.variable('b'), DF.literal('b2') ],
+                ]),
+              ]),
+              metadata: () => Promise.resolve(
+                {
+                  state: new MetadataValidationState(),
+                  cardinality: { type: 'estimate', value: 6 },
+                  pageSize: 100,
+                  requestTime: 30,
+
+                  variables: [
+                    { variable: DF.variable('a'), canBeUndef: false },
+                    { variable: DF.variable('b'), canBeUndef: false },
+                  ],
+                },
+              ),
+              type: 'bindings',
+            },
+            operation: <any> {},
+          },
+          {
+            output: {
+              bindingsStream: new ArrayIterator<RDF.Bindings>([
+                BF.bindings([
+                  [ DF.variable('a'), DF.literal('a1') ],
+                  [ DF.variable('d'), DF.literal('d1') ],
+                ]),
+                BF.bindings([
+                  [ DF.variable('a'), DF.literal('a2') ],
+                  [ DF.variable('d'), DF.literal('d2') ],
+                ]),
+              ]),
+              metadata: () => Promise.resolve(
+                {
+                  state: new MetadataValidationState(),
+                  cardinality: { type: 'estimate', value: 7 },
+                  pageSize: 100,
+                  requestTime: 40,
+
+                  variables: [
+                    { variable: DF.variable('a'), canBeUndef: false },
+                    { variable: DF.variable('d'), canBeUndef: false },
+                  ],
+                },
+              ),
+              type: 'bindings',
+            },
+            operation: <any> {},
+          },
+        ],
+        context,
+      });
     });
 
     async function getSideData(action: IActionRdfJoin): Promise<IActorRdfJoinMultiSmallestTestSideData> {
       return (await actor.test(action)).getSideData();
     }
+
+    it('should correctly identify the smallest streams with overlapping variables', () => {
+      const entries = [
+        createEntry([ 'a', 'b' ], 2),
+        createEntry([ 'a' ], 5),
+        createEntry([ 'b' ], 10),
+      ];
+      const joinIndexes = actor.getJoinIndexes(entries);
+      expect(joinIndexes).toEqual([ 0, 1 ]);
+    });
+
+    it('should correctly avoid cartesian join', () => {
+      const entries = [
+        createEntry([ 'a', 'b' ], 2),
+        createEntry([ 'c' ], 5),
+        createEntry([ 'b' ], 10),
+      ];
+      const joinIndexes = actor.getJoinIndexes(entries);
+      expect(joinIndexes).toEqual([ 0, 2 ]);
+    });
+
+    it('should correctly choose cartesian join when no variables overlap', () => {
+      const entries = [
+        createEntry([ 'a' ], 2),
+        createEntry([ 'b' ], 5),
+        createEntry([ 'c' ], 10),
+      ];
+      const joinIndexes = actor.getJoinIndexes(entries);
+      expect(joinIndexes).toEqual([ 0, 1 ]);
+    });
 
     it('should not test on 0 streams', async() => {
       await expect(actor.test({ type: 'inner', entries: [], context })).resolves
@@ -350,6 +503,16 @@ IActorRdfJoinSelectivityOutput
       }
     });
 
+    it('should test 4 streams when vars disjoint in 2 smallest', async() => {
+      const action = action5();
+      await expect(actor.test(action)).resolves.toPassTest({
+        iterations: 840,
+        persistedItems: 0,
+        blockingItems: 0,
+        requestTime: 6,
+      });
+    });
+
     it('should run on 3 streams', async() => {
       const action = action3();
       const output = await actor.run(action, await getSideData(action));
@@ -364,6 +527,7 @@ IActorRdfJoinSelectivityOutput
           { variable: DF.variable('b'), canBeUndef: false },
         ],
       });
+
       await expect(output.bindingsStream).toEqualBindingsStream([
         BF.bindings([
           [ DF.variable('a'), DF.literal('a1') ],
@@ -421,3 +585,28 @@ IActorRdfJoinSelectivityOutput
     });
   });
 });
+
+// Helper to create an entry with specified variables and cardinality
+function createEntry(vars: string[], cardinality: number): IJoinEntryWithMetadata {
+  return {
+    output: {
+      bindingsStream: new ArrayIterator<RDF.Bindings>([]),
+      metadata: () => Promise.resolve({
+        state: new MetadataValidationState(),
+        cardinality: { type: 'estimate', value: cardinality },
+        pageSize: 100,
+        requestTime: 30,
+        variables: vars.map(v => ({ variable: DF.variable(v), canBeUndef: false })),
+      }),
+      type: 'bindings',
+    },
+    operation: <any>{},
+    metadata: {
+      state: new MetadataValidationState(),
+      cardinality: { type: 'estimate', value: cardinality },
+      pageSize: 100,
+      requestTime: 30,
+      variables: vars.map(v => ({ variable: DF.variable(v), canBeUndef: false })),
+    },
+  };
+}

--- a/packages/bus-rdf-join/lib/ActorRdfJoin.ts
+++ b/packages/bus-rdf-join/lib/ActorRdfJoin.ts
@@ -185,7 +185,7 @@ TS
   }
 
   /**
-   * Obtain the join entries witt metadata from all given join entries.
+   * Obtain the join entries with metadata from all given join entries.
    * @param entries Join entries.
    */
   public static async getEntriesWithMetadatas(entries: IJoinEntry[]): Promise<IJoinEntryWithMetadata[]> {

--- a/performance/benchmark-watdiv-file/combinations/combination_0/input/config-client.json
+++ b/performance/benchmark-watdiv-file/combinations/combination_0/input/config-client.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/config-query-sparql/^3.0.0/components/context.jsonld"
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/config-query-sparql/^4.0.0/components/context.jsonld"
   ],
   "import": [
     "ccqs:config/config-file.json"

--- a/performance/benchmark-watdiv-file/combinations/combination_1/input/config-client.json
+++ b/performance/benchmark-watdiv-file/combinations/combination_1/input/config-client.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/config-query-sparql/^3.0.0/components/context.jsonld"
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/config-query-sparql/^4.0.0/components/context.jsonld"
   ],
   "import": [
     "ccqs:config/config-file.json"

--- a/performance/benchmark-watdiv-file/input/config-client.json
+++ b/performance/benchmark-watdiv-file/input/config-client.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/config-query-sparql/^3.0.0/components/context.jsonld"
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/config-query-sparql/^4.0.0/components/context.jsonld"
   ],
   "import": [
     "ccqs:config/config-file.json"


### PR DESCRIPTION
This improves performance when bind-join is not or can not be used.